### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/hugo_publisher.yml
+++ b/.github/workflows/hugo_publisher.yml
@@ -43,7 +43,7 @@ jobs:
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Checkout
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.6
         with:
           submodules: recursive
 

--- a/.github/workflows/img.yml
+++ b/.github/workflows/img.yml
@@ -20,7 +20,7 @@ jobs:
     # Only run on main repo on and PRs that match the main repo.
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.6
       - name: Compress Images
         id: calibre
         uses: calibreapp/image-actions@1.1.0

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4.1.5
+            - uses: actions/checkout@v4.1.6
               with:
                   # [Required] Access token with `workflow` scope.
                   token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.6](https://github.com/actions/checkout/releases/tag/v4.1.6)** on 2024-05-16T18:11:28Z
