### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/hugo_publisher.yml
+++ b/.github/workflows/hugo_publisher.yml
@@ -43,7 +43,7 @@ jobs:
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Checkout
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.7
         with:
           submodules: recursive
 

--- a/.github/workflows/img.yml
+++ b/.github/workflows/img.yml
@@ -20,7 +20,7 @@ jobs:
     # Only run on main repo on and PRs that match the main repo.
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.7
       - name: Compress Images
         id: calibre
         uses: calibreapp/image-actions@1.1.0
@@ -29,7 +29,7 @@ jobs:
           # For non-Pull Requests, run in compressOnly mode and we'll PR after.
           compressOnly: ${{ github.event_name != 'pull_request' }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6.0.5
+        uses: peter-evans/create-pull-request@v6.1.0
         with:
           title: Auto Compress Images
           branch-suffix: timestamp

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4.1.5
+            - uses: actions/checkout@v4.1.7
               with:
                   # [Required] Access token with `workflow` scope.
                   token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.1.0](https://github.com/peter-evans/create-pull-request/releases/tag/v6.1.0)** on 2024-06-18T16:54:59Z
